### PR TITLE
Remove the app market sidebar

### DIFF
--- a/app/client/stylesheets/variables.scss
+++ b/app/client/stylesheets/variables.scss
@@ -122,8 +122,9 @@ $banner-font-color: #594590;
 $button-border-radius: 0.5rem;
 
 $topbar-height: 8.5rem;
-$topbar-logo-icon-size: 6.044rem;
+$topbar-logo-icon-size: 5.5rem;
 $topbar-logo-margin-left: 2.5rem;
+$topbar-logo-text-font-size: 2.5rem;
 $topbar-padding-bottom: 1.667rem;
 $topbar-item-font-size: 1.6rem;
 $topbar-item-padding-lr: 1.2rem;
@@ -140,7 +141,7 @@ $menu-item-padding-tb: 2.333rem;
 $menu-box-shadow: 0.25rem 0.25rem $app-box-drp-shdw;
 
 $app-section-width: 104.167rem;
-$app-section-padding-left: 8rem;
+$app-section-padding-left: $topbar-logo-margin-left;
 $app-section-padding-right: 11.3rem;
 $app-genre-margin-top: 5.417rem;
 $app-genre-margin-bottom: 1.333rem;

--- a/app/client/stylesheets/variables.scss
+++ b/app/client/stylesheets/variables.scss
@@ -124,7 +124,7 @@ $button-border-radius: 0.5rem;
 $topbar-height: 8.5rem;
 $topbar-logo-icon-size: 5.5rem;
 $topbar-logo-margin-left: 2.5rem;
-$topbar-logo-text-font-size: 2.5rem;
+$topbar-logo-text-font-size: 2.2rem;
 $topbar-padding-bottom: 1.667rem;
 $topbar-item-font-size: 1.6rem;
 $topbar-item-padding-lr: 1.2rem;

--- a/app/client/templates/components/menu.html
+++ b/app/client/templates/components/menu.html
@@ -1,30 +1,6 @@
 <template name="Menu">
 
   <nav class="menu-container">
-
-    <a class="menu-link {{inRouteCategory 'appMarket'}}" href="{{getPath 'appMarket'}}">
-      <i class="icon-market"></i>
-      <div class="menu-text">App Market</div>
-    </a>
-
-    {{#if false}}
-    <a class="menu-link {{inRouteCategory 'installedApps'}}" href="{{getPath 'installedApps'}}">
-      <i class="icon-apps"></i>
-      <div class="menu-text">Install History</div>
-    </a>
-    {{/if}}
-
-    <a class="menu-link {{inRouteCategory 'upload'}} hide-for-phone"
-       href="https://docs.sandstorm.io/en/latest/developing/publishing-apps/" target="_blank">
-      <i class="icon-upload"></i>
-      <div class="menu-text">Upload an App</div>
-    </a>
-
-    <a class="menu-link {{inRouteCategory 'login'}}" href="{{getPath 'login'}}">
-      <i class="icon-my"></i>
-      <div class="menu-text">{{#if currentUser}}{{currentUser.profile.name}}{{else}}Log In{{/if}}</div>
-    </a>
-
   </nav>
 
 </template>

--- a/app/client/templates/components/menu.scss
+++ b/app/client/templates/components/menu.scss
@@ -145,8 +145,9 @@ body.admin {
   }
 
   .menu-spacer {
+    color: blue;
 
-    margin-left: 12.5rem;
+    margin-left: $topbar-logo-margin-left;
 
     @media screen and (max-width: $medium-tablet) {
 
@@ -172,7 +173,7 @@ body.admin {
 
 .menu-spacer {
 
-  margin-left: $menu-width + $app-section-padding-left;
+  margin-left: $app-section-padding-left;
   position: relative;
 
   @media screen and (max-width: $medium-tablet) {

--- a/app/client/templates/components/topbar.html
+++ b/app/client/templates/components/topbar.html
@@ -3,10 +3,8 @@
   <div class="topbar-container">
 
     <a class="logo-box" href="/">
-
-      <i class="icon-logo show-above-phone"></i>
-      <i class="icon-logo-image hide-above-phone"></i>
-
+      <i class="icon-logo-image"></i>
+      <span class="show-above-phone">Sandstorm App Market</span>
     </a>
 
     <div class="genre-holder">

--- a/app/client/templates/components/topbar.scss
+++ b/app/client/templates/components/topbar.scss
@@ -14,6 +14,7 @@
 
     span {
       font-size: $topbar-logo-text-font-size;
+      font-weight: normal;
       display: inline;
     }
 

--- a/app/client/templates/components/topbar.scss
+++ b/app/client/templates/components/topbar.scss
@@ -10,20 +10,23 @@
 
     position: absolute;
     left: $topbar-logo-margin-left;
-    bottom: $topbar-padding-bottom;
     color: $topbar-logo-text;
 
+    span {
+      font-size: $topbar-logo-text-font-size;
+      display: inline;
+    }
+
     i {
-
+      display: inline;
       font-size: $topbar-logo-icon-size;
-
     }
 
   }
 
   .genre-holder {
 
-    margin-left: $menu-width + $app-section-padding-left;
+    margin-left: $app-section-padding-left;
     margin-right: 32rem;
     position: relative;
     height: $topbar-height;

--- a/app/client/templates/home/home.scss
+++ b/app/client/templates/home/home.scss
@@ -12,12 +12,10 @@ body {
   position: relative;
   height: $welcome-message-height;
   background-color: #cad4ef;
-  background-position: $menu-width 0;
   background-size: auto 100%;
   background-repeat: no-repeat;
   background-image: url('images/welcome-banner.png');
   overflow: hidden;
-  padding-left: $menu-width;
 
   @media screen and (max-width: $medium-tablet) {
 
@@ -91,7 +89,6 @@ body {
   font-size: 250%;
   color: #783189;
   border-top: 1px solid #879ac1;
-  margin-left: $menu-width;
   text-align: center;
   padding: 1rem;
   @media screen and (max-width: $medium-tablet) {


### PR DESCRIPTION
In the process:

- Center background text independent of the sidebar.

- Explain in the corner this is the Sandstorm App Market.

- Tweak the font size of the Sandstorm logo icon for similar visual size
  as before.

Close #31

This change ends up removing a lot of styling and HTML. I am making it minimal in
case we want to bring the sidebar back once we restore its functionality.