### PR TITLE
Add nested-span hack to work around display: inherit;

### DIFF
--- a/app/client/templates/components/topbar.html
+++ b/app/client/templates/components/topbar.html
@@ -4,7 +4,7 @@
 
     <a class="logo-box" href="/">
       <i class="icon-logo-image"></i>
-      <span class="show-above-phone">Sandstorm App Market</span>
+      <span class="logo-text-formatting"><span class="show-above-phone">Sandstorm App Market</span></span>
     </a>
 
     <div class="genre-holder">

--- a/app/client/templates/components/topbar.scss
+++ b/app/client/templates/components/topbar.scss
@@ -12,10 +12,9 @@
     left: $topbar-logo-margin-left;
     color: $topbar-logo-text;
 
-    span {
+    > span {
       font-size: $topbar-logo-text-font-size;
       font-weight: normal;
-      display: inline;
     }
 
     i {


### PR DESCRIPTION
Sorry @kentonv for horrible CSS here.

Rationale:

- `show-above-phone` contains `display: inherit;`
- which resulted in the SPAN inheriting `display: block;`

I'm going to self-merge.