### PR TITLE
Update release process to account for recent Sansdtorm changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,24 @@ You can obtain the required credentials as follows:
 * Change the homepage to match your site's homepage (or *http://localhost:3000* if running in development). Change the authorized redirect URL to *[HOMEPAGE]/_oauth/github*.
 * The Client ID and Secret will appear near the top of the page after you submit.
 
+### Release process
+
+Our release process for the app market involves taking a Sandstorm bundle, ripping out the Sandstorm front-end, and inserting the App Market code in its place. It turns out the Sandstorm bundle-runner is an excellent way to run arbitrary Meteor apps for the same reasons that it is an excellent way to run Sandstorm itself:
+
+- It takes care of Mongo, including setting up authentication intelligently, configuring oplog tailing (hard!), and recovering from crashes.
+- It auto-restarts Node and Mongo when they crash.
+- It makes updates trivial ("sandstorm update <tarball>").
+- We have a lot of experience wrangling the Sansdtorm bundle runner, compared to alternatives like Meteor-Up.
+
+To build a release, you must:
+
+1. Check out the Sandstorm code and do `make sandstorm-0-fast.tar.xz`.
+2. Copy `sandstorm-0-fast.tar.xz` to the App Market source directory.
+3. Run `./make-bundle.sh sandstorm-0-fast.tar.xz market.tar.xz` to build `market.tar.xz`, the App Market release bundle.
+
+Once you have `market.tar.xz`, you can install it over an existing Sansdtorm install, or even use it as input to Sandstorm's `install.sh`. For example:
+
+* `sandstorm update market.tar.xz`: "Update" an existing Sandstorm (or App Market) install to the new App Market bundle.
+* `sandstorm/install.sh market.tar.xz`: Use the Sandstorm installer to install the App Market. Note that most of the installer prompts don't make sense. You should do a custom install with no Sandcats and no HTTPS.
+
+The file `release.sh` is a script which automates updating Sandstorm's official App Market server. To use this script, your `PATH` must contain a command `gce-ss` which expands to `gcloud compute "$@"` with Google Cloud zone and project ID set accordingly.

--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -72,15 +72,8 @@ METEOR_DEV_BUNDLE=$(./find-meteor-dev-bundle.sh)
 # ====================================================================
 status "merging bundles"
 
-# HACK: inject app store settings into sandstorm-main.js
-cat > build/bundle/sandstorm-main.js << __EOF__
-process.env.METEOR_SETTINGS = JSON.stringify({
-  public: {
-    API_URL: "https://app-index.sandstorm.io"
-  }
-});
-__EOF__
-cat sandstorm-0/sandstorm-main.js >> build/bundle/sandstorm-main.js
+# Overwrite sandstorm-main.js with one that doesn't do all the HTTPS stuff we don't need.
+cp meteor-bundle-main.js build/bundle/sandstorm-main.js
 
 for file in build/bundle/*; do
   rm -rf sandstorm-0/$(basename $file)

--- a/meteor-bundle-main.js
+++ b/meteor-bundle-main.js
@@ -1,0 +1,20 @@
+// Inject custom Meteor.settings, overriding the ones passed it by the bundle runner which
+// are really meant for the Sandstorm front-end.
+process.env.METEOR_SETTINGS = JSON.stringify({
+  public: {
+    API_URL: "https://app-index.sandstorm.io"
+  }
+});
+
+// This file is used by Sandstorm to monkey-patch certain classes/functions in Nodejs
+// Specifically, we're changing http.Server.listen to listen on fd=3 instead of the normal
+// parameters. This is fine to do globally, since there's only ever one http server in meteor.
+var http = require('http');
+var net = require('net');
+
+var oldListen = http.Server.prototype._oldListen = http.Server.prototype.listen;
+http.Server.prototype.listen = function (port, host, cb) {
+  oldListen.call(this, {fd: 3}, cb);
+}
+
+require("./main.js");


### PR DESCRIPTION
So, our release process for the app market involves taking a Sandstorm bundle, ripping out the Sandstorm front-end, and inserting the App Market code in its place. It turns out the Sandstorm bundle-runner is an excellent way to run arbitrary Meteor apps for the same reasons that it is an excellent way to run Sandstorm itself:
- It takes care of Mongo, including setting up authentication intelligently, configuring oplog tailing (hard!), and recovering from crashes.
- It auto-restarts Node and Mongo when they crash.
- It makes updates trivial ("sandstorm update <tarball>").
- We have a lot of experience wrangling the Sansdtorm bundle runner, compared to alternatives like mup.

However, the process had been working so well that I became complacent, basically relying on `release.sh` to do the right thing without the need to test. Until today, that had always just worked.

Today, though, there were problems:
- A recent change updated the version of Meteor, which in turn requires a newer version of Node. I had been using an old version of the Sandstorm bundle with an old Node as the basis for Market releases, so the result was a server that refused to start. Unfortunately due to my complacency this problem was not caught until hitting production.
- I frantically built a new Sansdtorm bundle based on the latest Sandstorm code and re-ran the release process, but this uncovered a new problem: Sandstorm's meteor-bundle-main.js had recently become much more complicated and had grown a dependency on node-forge, which was not in the App Market's dependency list. Hence, after building against a newer Sandstorm bundle, the server still failed to start, for a completely different reason.

This change fixes the latter problem by introducing our own meteor-bundle-main.js which we use in place of Sandstorm's. It is based on the old meteor-bundle-main.js from the old bundle that I had been using.