### PR TITLE
Quick fix for description cut off

### DIFF
--- a/app/client/templates/single-app/single-app.scss
+++ b/app/client/templates/single-app/single-app.scss
@@ -495,7 +495,7 @@ $app-container-padding-rl: 4.6rem;
 
     &.padded {
       padding-top: 2rem;
-      padding-bottom: 2rem;
+      padding-bottom: 4rem;
     }
 
     &.min-height {
@@ -503,7 +503,7 @@ $app-container-padding-rl: 4.6rem;
     }
 
     &.max-height {
-      max-height: 28rem;
+      max-height: 50rem;
     }
 
     .fade-box {


### PR DESCRIPTION
This won't help app descriptions that are over a page long but those are probably too long anyway... This is a sufficient fix in the short term but I'll add a button to expand descriptions in the future (similar to what exists in the initial mock-ups).