### PR TITLE
Stop changing font-size based on body width

### DIFF
--- a/app/client/stylesheets/main.scss
+++ b/app/client/stylesheets/main.scss
@@ -144,7 +144,6 @@ html {
   font-family: $main-font;
   font-weight: 300;
   font-size: 9px;
-  font-size: 0.65vw;
 
   @media (max-width: $small-screen) {
 

--- a/app/client/templates/single-app/single-app.scss
+++ b/app/client/templates/single-app/single-app.scss
@@ -37,10 +37,6 @@ $app-container-padding-rl: 4.6rem;
       margin-top: 2.5rem;
       height: 26.5rem;
 
-      @media (min-width: $large-phone) and (max-width: $small-tablet) {
-        height: 60vw;
-      }
-
       .image-surround-full-width {
 
         position: relative;


### PR DESCRIPTION
Context: The app market used to use viewport-sized typography, per e.g. https://css-tricks.com/viewport-sized-typography/
but @neynah and I found it jarring.