### PR TITLE
When visiting nonexistent apps, show a 404

### DIFF
--- a/app/client/templates/single-app/single-app.js
+++ b/app/client/templates/single-app/single-app.js
@@ -15,6 +15,10 @@ Template.SingleApp.onCreated(function() {
         if (!app.screenshots.length) tmp.readMore.set(true);
       }
     } catch (err) {
+      if (err.toString().startsWith("Error: failed [404]")) {
+        BlazeLayout.render('MasterLayout', {mainSection: 'NotFound'});
+        return;
+      }
       console.error(err);
       // TODO: This doesn't work as there is no `errorModal` template.
       AntiModals.overlay('errorModal', {data: {err: 'There was an error loading app data from the server'}});


### PR DESCRIPTION
This is somewhat of a hack, since it only shows a 404 message, but the HTTP response is
still HTTP 200. It's all via Meteor DDP. My main other option is to do a client-side
redirect and change the URL, which seems worse.

Close #44