### PR TITLE
Use a HREF for app cards on homepage

### DIFF
--- a/app/client/templates/components/app-item.html
+++ b/app/client/templates/components/app-item.html
@@ -1,7 +1,6 @@
 <template name="appItem">
 
-  <div class="app-item-container {{size}} {{appInstalled.cssClass}}" data-link="single-app">
-
+  <div class="app-item-container {{size}} {{appInstalled.cssClass}}"><a href="/app/{{app._id}}">
     <div class="app-item-inner">
 
       {{#if equal size "large"}}
@@ -75,7 +74,7 @@
 
     </div>
 
-  </div>
+  </a></div>
 
 </template>
 

--- a/app/client/templates/components/app-item.js
+++ b/app/client/templates/components/app-item.js
@@ -97,24 +97,6 @@ Template.appItem.helpers({
   },
 });
 
-Template.appItem.events({
-
-  'click [data-action="uninstall-app-modal"]': function(evt) {
-
-    evt.stopPropagation();
-    AntiModals.overlay('uninstallApp', {data: this});
-
-  },
-
-  'click [data-link="single-app"]': function(evt) {
-
-    // We need to check if they've actually clicked on a link before redirecting
-    if (!evt.target.href && !evt.target.parentElement.href) FlowRouter.go('singleApp', {appId: this.app._id});
-
-  }
-
-});
-
 Template.appItemFullWidth.helpers({
 
   free: function(price) {

--- a/app/client/templates/components/app-rating.js
+++ b/app/client/templates/components/app-rating.js
@@ -24,7 +24,9 @@ Template.appRating.events({
 
   'click [data-action="rate-app"]': function(evt, tmp) {
 
-    evt.stopImmediatePropagation();
+    // Sometimes the appRating template is rendered within a HTML A HREF link, such as within the
+    // category page. This allows us to handle the click instead of navigating the browser.
+    evt.preventDefault();
     var app = Template.parentData(1);
 
     if (!Meteor.userId()) {


### PR DESCRIPTION
Close #32

Also:

- Remove the code that handles clicks to a now-nonexistent feature, uninstall-app-modal

- Adjust the app ratings code so that it properly prevents page navigation to the app
  page.