### PR TITLE
Mobile usability and layout fixes

### DIFF
--- a/app/client/stylesheets/main.scss
+++ b/app/client/stylesheets/main.scss
@@ -72,7 +72,7 @@
 .icon-approved_dark:before { content: "\f102"; }
 .icon-approved_light:before { content: "\f103"; }
 .icon-apps:before { content: "\f104"; }
-.icon-arrow-install:before { content: "\f105";   position: relative; top: -0.3em; }
+.icon-arrow-install:before { content: "\f105";   position: relative; top: -0.3em; height: 3rem; width: 2.5rem;}
 .icon-chevron-right:before { content: "\003e"; font-family: $main-font; }
 .icon-edit:before { content: "\f106"; }
 .icon-fb:before { content: "\f107"; }
@@ -180,6 +180,11 @@ html {
 .left-float {
   float: left;
   clear: none;
+  
+  @media (max-width: 600px) {
+    border-top: 1px solid #cfb5d6;
+    width: 100%;
+  }
 
   &.block-phone {
     @media (max-width: $medium-tablet) {
@@ -189,8 +194,13 @@ html {
 }
 
 .right-float {
-  float: right;
+  text-align: right;
   clear: none;
+  float: right;
+  @media (max-width: 600px) {
+    text-align: left;
+    width: 100%;
+  }
 
   & +.right-float {
     margin-right: 2rem;

--- a/app/client/stylesheets/variables.scss
+++ b/app/client/stylesheets/variables.scss
@@ -152,7 +152,7 @@ $app-genre-margin-top: 5.417rem;
 $app-genre-margin-bottom: 1.333rem;
 $app-container-width: 21.3rem;
 $app-container-width-large: $app-container-width * 3;
-$app-container-height: 32rem;
+$app-container-height: 33rem;
 $app-container-min-width: 120px;
 $app-container-max-width: 200px;
 $app-container-margin-lr: 1.167rem;

--- a/app/client/templates/components/app-item-full-width.scss
+++ b/app/client/templates/components/app-item-full-width.scss
@@ -23,7 +23,6 @@
         position: relative;
         height: 85%;
         width: 23rem;
-        min-width: 15rem;
 
         .image {
 

--- a/app/client/templates/components/app-item.scss
+++ b/app/client/templates/components/app-item.scss
@@ -136,8 +136,8 @@
         display: block;
         font-size: $app-install-font-size;
         font-weight: normal;
-        padding-top: $app-install-padding-tb;
-        padding-bottom: $app-install-padding-tb;
+        padding-top: 0.6rem;
+        padding-bottom: 0;
         padding-left: $app-install-padding-lr;
         padding-right: $app-install-padding-lr;
         min-width: 9rem;

--- a/app/client/templates/components/app-rating.scss
+++ b/app/client/templates/components/app-rating.scss
@@ -36,6 +36,9 @@
       color: #783189;
       font-size: 1.35rem;
       font-weight: 400;
+      @media (max-width: 350px) {
+        font-size: 1.2rem;
+      }
 
       &.table {
         display: block;
@@ -93,10 +96,14 @@
         $bar-height: 1.25rem;
 
         display: block;
-        width: 15rem;
+        width: 15.5rem;
         position: relative;
         z-index: 0;
         height: $bar-height;
+        
+        @media (max-width: $medium-phone) {
+          width: 13rem;
+        }
 
         .background {
           background-color: $review-negative-color;

--- a/app/client/templates/components/components.scss
+++ b/app/client/templates/components/components.scss
@@ -23,8 +23,9 @@
   cursor: pointer;
   font-weight: 300;
   height: 4rem;
-  line-height: 3.1rem;
+  line-height: 3.5rem;
   font-size: 1.9rem;
+  margin: 0.4rem 0.2rem;
 
   i {
     color: $update-selector-button-icon;

--- a/app/client/templates/single-app/single-app.html
+++ b/app/client/templates/single-app/single-app.html
@@ -161,25 +161,7 @@
               <div class="rating">
                 {{> appRating app=this}}
               </div>
-              {{#if shouldShowEditReviewLink}}
-              <div class="option option-text" data-action="edit-review">
-                <span>
-                  Edit your review
-                  <i class="fa fa-caret-down"></i>
-                </span>
-              </div>
-              {{else}}
-              <div class="write-review option-text">
-                {{#unless reviewExistsServerSide}}
-                <span>
-                  Write a review
-                </span>
-                {{/unless}}
-                  {{> myRatingBox rating=myReview.rating writeReview=writeReview}}
-              </div>
-              {{/if}}
-            </div>
-            <div class="review-breakdown-and-textarea">
+              <div class="review-breakdown-and-textarea">
               <div class="review-breakdown">
                 {{#if ratingsCount}}
                 <table class="review-breakdown-table">
@@ -214,21 +196,39 @@
                 </table>
                 {{/if}}
               </div>
-              <div class="review-entry-and-buttons">
-                <div>
-                  <textarea maxlength="500" class="review-entry {{#unless writeReview}}hidden{{/unless}}" style="{{#unless writeReview or ratingsCount}}display: none;{{/unless}}" data-field="review-text">{{myReview.text}}</textarea>
+            </div>
+              {{#if shouldShowEditReviewLink}}
+              <div class="option option-text">
+                <span data-action="edit-review">
+                  Edit your review
+                  <i class="fa fa-caret-down"></i>
+                </span>
+              </div>
+              {{else}}
+              <div class="write-review option-text">
+                {{#unless reviewExistsServerSide}}
+                <span>
+                  Write a review
+                </span>
+                {{/unless}}
+                  {{> myRatingBox rating=myReview.rating writeReview=writeReview}}
+              </div>
+              {{/if}}
+            </div>
+            <div class="review-entry-and-buttons">
+              <div>
+                <textarea maxlength="500" class="review-entry {{#unless writeReview}}hidden{{/unless}}" style="{{#unless writeReview or ratingsCount}}display: none;{{/unless}}" data-field="review-text">{{myReview.text}}</textarea>
+              </div>
+              <div class="button-block">
+                <div class="sandstorm-button {{#if reviewValid}}primary{{else}}neutral submit{{/if}} {{#unless writeReview}}hidden{{/unless}}" data-action="{{#if reviewValid}}submit-review{{else}}review-tooltip{{/if}}">
+                  Submit review
                 </div>
-                <div class="button-block">
-                  <div class="sandstorm-button {{#if reviewValid}}primary{{else}}neutral submit{{/if}} {{#unless writeReview}}hidden{{/unless}}" data-action="{{#if reviewValid}}submit-review{{else}}review-tooltip{{/if}}">
-                    Submit review
-                  </div>
-                  <div class="sandstorm-button neutral {{#unless writeReview}}hidden{{/unless}}" data-action="discard-review">
-                    <i class="icon-garbage"></i>
-                    <span class="text">Discard</span>
-                  </div>
-                  <div class="sandstorm-button neutral {{#unless writeReview}}hidden{{/unless}}" data-action="cancel-review">
-                    <span class="text">Cancel</span>
-                  </div>
+                <div class="sandstorm-button neutral {{#unless writeReview}}hidden{{/unless}}" data-action="discard-review">
+                  <i class="icon-garbage"></i>
+                  <span class="text">Discard</span>
+                </div>
+                <div class="sandstorm-button neutral {{#unless writeReview}}hidden{{/unless}}" data-action="cancel-review">
+                  <span class="text">Cancel</span>
                 </div>
               </div>
             </div>

--- a/app/client/templates/single-app/single-app.scss
+++ b/app/client/templates/single-app/single-app.scss
@@ -42,14 +42,12 @@ $app-container-padding-rl: 4.6rem;
         position: relative;
         height: 85%;
         width: 23rem;
-        min-width: 15rem;
 
         .image {
 
           content: "";
           background-size: contain;
           background-repeat: no-repeat;
-          background-position: center;
           display: block;
           height: 100%;
 
@@ -60,24 +58,35 @@ $app-container-padding-rl: 4.6rem;
     }
 
     .header-row {
-      text-align: justify;
+      text-align: justify; 
+      width: 100%;
+      @media (max-width: $small-tablet) {
+        text-align: inherit;
+      }
+      .app-rating-container {
+        padding: 0.5rem 4.5rem 0.5rem 0;
+      }
     }
 
     .header {
-      display: inline-block;
+      display: block;
       vertical-align: bottom;
       font-weight: normal;
       clear: none;
       font-size: 3.1rem;
+      padding-bottom: 1rem;
     }
 
     .option-text {
-
       display: inline-block;
-      vertical-align: bottom;
       font-size: 1.7rem;
-
-      &.option {
+      width: 100%;
+      text-align: right;
+      position: relative;
+      right: 0;
+    
+      span {
+        display: block;
         cursor: pointer;
       }
 
@@ -99,6 +108,11 @@ $app-container-padding-rl: 4.6rem;
       // height: 26.5rem;
       overflow-y: hidden;
       margin-top: 1.8rem;
+      margin-bottom: 4rem;
+      
+      @media (max-width: 450px) {
+        overflow-y: inherit;
+      }
 
       .top-section {
         display: -webkit-flex;
@@ -109,6 +123,10 @@ $app-container-padding-rl: 4.6rem;
         align-items: flex-end;
         border-bottom: 1px solid #cfb5d6;
         color: #222222;
+        
+        @media (max-width: $medium-tablet) {
+          display: block;
+        }
 
         .app-name-full-width {
           float: left;
@@ -127,19 +145,23 @@ $app-container-padding-rl: 4.6rem;
           .button {
             display: inline-block;
             /* margin here pads the entire .top-section. */
-            margin-bottom: 0.5rem;
-
+            margin-bottom: 1rem;
+            margin-left: 0.5rem;
             height: 2.7rem;
             line-height: 2.7rem;
             font-size: 1.5rem;
-            padding-left: 1rem;
-            padding-right: 1rem;
+            padding: 0.4rem 1rem;
             background-color: inherit;
-            border-color: #e7daeb;
+            border-color: #cec2d2;
             border-radius: 0.5rem;
             border-style: solid;
             border-width: 1px;
             color: #783189;
+            @media (max-width: 460px) {
+              padding: 0.4rem 0.5rem;
+              font-size: 1.5rem;
+              margin-left: 0;
+            }
             i.fa {
               padding-right: 2px;
             }
@@ -234,11 +256,12 @@ $app-container-padding-rl: 4.6rem;
     }
 
     .half-col {
-
       display: inline-block;
       vertical-align: top;
       width: 50%;
-
+      @media (max-width: 480px) {
+        width: 100%;
+      }
     }
 
     .half-col.right {
@@ -248,57 +271,86 @@ $app-container-padding-rl: 4.6rem;
       width: auto;
       max-width: 50%;
       overflow: hidden;
+      @media (max-width: 480px) {
+        float: inherit;
+        margin: 1rem 0 1rem 0;
+        max-width: none;
+      }
     }
-
   }
 
-  @media (max-width: $small-tablet) {
-
-    .app-item-inner {
-
+  .app-item-inner {
+    @media (max-width: $small-tablet) and (min-width: 481px) {
       padding-left: 2.3rem;
       padding-right: 2.3rem;
-
-      .image-section {
-        margin-right: 0;
-        width: 100%;
-
-        .image-surround-full-width {
+    }
+    @media (max-width: 480px) {
+      padding: 1rem 2rem;
+    }
+    
+    .image-section {
+      @media (max-width: $small-tablet) and (min-width: 481px) {
+        margin-right: 2rem;
+        height: 15rem;
+      }
+      @media (max-width: 480px) and (min-width: 421px) {
+        width: 7rem;
+        height: 10rem;
+      }
+      @media (max-width: 420px) {
+        width: 5rem;
+        height: 7rem;
+      }
+      
+      .image-surround-full-width {
+        @media (max-width: $small-tablet) and (min-width: 481px) {
+          width: 12rem;
+        }
+        @media (max-width: 480px) and (min-width: 421px) {
+          width: 8rem;
+        }
+        @media (max-width: 420px) {
+          width: 6rem;
+        }
+      }
+    }
+    
+    .text-section {
+      @media (max-width: $small-tablet) and (min-width: 481px) {
+        .half-col {
+          display: block;
           width: 100%;
-        }
-      }
-
-      .text-section {
-          overflow-y: initial;
-
-          .half-col {
-            display: block;
+          margin-bottom: 1rem;
+          @media (max-width: $small-tablet) {
             width: 100%;
-            margin-bottom: 1rem;
-          }
-
-          .half-col.right {
-            float: none;
-            max-width: none;
-          }
-      }
-
-      [data-action="flag-app"], [data-action="write-review"] {
-        display: none;
-      }
-
-      .description {
-        .text.padded {
-          >*:first-child {
-            margin-top: 0;
           }
         }
-      }
 
+        .half-col.right {
+          float: none;
+          max-width: none;
+        }
+      }
+    }
+    
+    .app-title {
+     @media (max-width: 350px) {
+       padding-bottom: 4rem;
+      } 
+    }
+    
+    [data-action="flag-app"], [data-action="write-review"] {
+      display: none;
     }
 
+    .description {
+      .text.padded {
+        >*:first-child {
+          margin-top: 0;
+        }
+      }
+    }
   }
-
 }
 
 .ratings-bar {
@@ -309,6 +361,12 @@ $app-container-padding-rl: 4.6rem;
   height: 3.5rem;
   font-size: 1.7rem;
   clear: both;
+  
+  @media (max-width: 600px) {
+    width: 100%;
+    display: block;
+    border-top: none;
+  }
 
   .app-rating, span, i {
 
@@ -712,16 +770,20 @@ $app-container-padding-rl: 4.6rem;
   }
 
   .review-bar {
+    padding-top: 1.5rem;
     display: -webkit-flex;
     display: flex;
     -webkit-flex-direction: row;
     flex-direction: row;
-    justify-content: space-between;
+    @media (max-width: 660px) {
+      display: inline-block;
+      flex-wrap: wrap;
+    }
 
     .rating {
       display: flex;
       flex-direction: row;
-      align-items: center;
+      min-width: 22rem;
       .app-rating-container .ratings .text .labels .amazing {
         font-size: 1.5rem;
       }
@@ -729,6 +791,36 @@ $app-container-padding-rl: 4.6rem;
 
     .write-review {
       line-height: 4rem;
+      @media (max-width: 950px) {
+        justify-content: space-between;
+      }
+      @media (max-width: $large-phone) {
+        width: 100%;
+        justify-content: space-between;
+        padding-bottom: 1.5rem;
+      }
+      @media (max-width: 660px) {
+        justify-content: space-between;
+      }
+      @media (max-width: 660px) and (min-width: 530px) {
+        flex-wrap: nowrap;
+        display: block;
+      }
+      
+      .sandstorm-button {
+        float: right;
+        @media (max-width: 980px) {
+          padding: 0 1.2rem;
+        }
+        @media (max-width: 950px) {
+          width: 47.5%;
+          text-align: center;
+          padding: 0;
+        }
+        @media (max-width: 660px) and (min-width: 530px) {
+          width: 23.5%;
+        }
+      }
 
       span {
         padding-right: $update-selector-button-padding-lr;
@@ -796,37 +888,56 @@ $app-container-padding-rl: 4.6rem;
         }
       }
     }
+  }
+  
+  .review-entry-and-buttons {
+    flex-grow: 1;
+    margin-top: 1rem;
+    @media (max-width: $small-tablet) {
+      display: block;
+    }
 
-    .review-entry-and-buttons {
-      flex-grow: 1;
+    .review-entry {
+      outline: none;
+      resize: vertical;
+      background-color: white;
+      border: 1px solid #b9acbb;
+      font-family: $main-font;
+      font-weight: 300;
+      font-size: 1.8rem;
+      margin-bottom: 0.8rem;
+      padding: 1.2rem;
+      box-sizing: border-box;
+      width: 100%;
+    }
 
-      .review-entry {
-        outline: none;
-        resize: none;
-        background-color: white;
-        border: 1px solid #e4dfe5;
-        color: #6d627c;
-        font-family: $main-font;
-        font-weight: 300;
-        font-size: 1.8rem;
-        margin-bottom: 0.8rem;
-        padding: 1.2rem;
-        box-sizing: border-box;
-        width: 100%;
-      }
+    .hidden {
+      // Use this, rather than display: none; to avoid flashes of re-layout.
+      visibility: hidden;
+    }
 
-      .hidden {
-        // Use this, rather than display: none; to avoid flashes of re-layout.
-        visibility: hidden;
-      }
-
-      .button-block {
-        text-align: right;
-        margin-bottom: 0.8rem;
-
-        .sandstorm-button.primary:hover {
-          background-color: #9247a9;
+    .button-block {
+      text-align: right;
+      margin-bottom: 0.8rem;
+      
+      @media (max-width: 400px) {
+        display: flex;
+        justify-content: space-between;
+        flex-wrap: nowrap;
+        
+        .sandstorm-button {
+          flex: 1;
+          padding: 0;
+          text-align: center;
+          overflow: hidden;
+          i {
+            margin-right: 0;
+          }
         }
+      }
+      
+      .sandstorm-button.primary:hover {
+        background-color: #9247a9;
       }
     }
   }

--- a/app/public/icons/sandstorm/sandstorm.css
+++ b/app/public/icons/sandstorm/sandstorm.css
@@ -72,7 +72,7 @@
 .icon-approved_dark:before { content: "\f102"; }
 .icon-approved_light:before { content: "\f103"; }
 .icon-apps:before { content: "\f104"; }
-.icon-arrow-install:before { content: "\f105"; }
+.icon-arrow-install:before { content: "\f105"; line-height: normal; }
 .icon-edit:before { content: "\f106"; }
 .icon-fb:before { content: "\f107"; }
 .icon-flagged_dark:before { content: "\f108"; }


### PR DESCRIPTION
Fixes #103. Changes in this PR are not visually perfect but are still significant usability improvements from our current UI.

**Changes:**
Single-app page (top):
- UI elements on single-app pages no longer fall outside of the view; looks reasonable on really small screens now (e.g. iPhone 5 (320px))
- App icon scales down on smaller screens
- Date, genre, and details text now takes up full width on smaller screens and now align cleanly on the left (with appropriate padding)
- App contact info buttons are now slightly larger and align to the left on smaller screens

Single-app page (reviews):
- Increased contrast of input box as well as text for leaving a review
- Buttons no longer get jumbled when there's not enough space for them
- Input box now takes up the full width that's available; "Review breakdown" has been shifted up beside the review bar to accommodate for this
- "Submit", "Discard", "Cancel" buttons remain in a single row instead of wrapping
 - "Write a review" text displays consistently in the top right corner
- "Write a review" buttons are no longer justified and now are aligned to the right
- Hide the word "Review" in "Submit Review" button when the screen width is 380px or less

Home page (app grid):
- Rating bar width no longer exceeds with of app card on small screens

New vs previous screenshots:
![image](https://cloud.githubusercontent.com/assets/855341/18975955/fc529dc4-8662-11e6-9b64-edc35b089042.png)
![image](https://cloud.githubusercontent.com/assets/855341/18975970/07ccf596-8663-11e6-8f51-e725727d0d52.png)
![image](https://cloud.githubusercontent.com/assets/855341/18975943/e3b661a6-8662-11e6-8bd6-e3932067ec60.png)
![image](https://cloud.githubusercontent.com/assets/855341/19011314/5b1b7f18-8746-11e6-959b-cfa6fde9d85a.png)
![image](https://cloud.githubusercontent.com/assets/855341/19011320/a06921ec-8746-11e6-8a6c-f5d5350230c3.png)
![image](https://cloud.githubusercontent.com/assets/855341/18975904/99abe6a8-8662-11e6-8deb-9db5072c3701.png)
![image](https://cloud.githubusercontent.com/assets/855341/18998366/4e91e48e-86ed-11e6-82e9-12031faf859e.png)
