### PR TITLE
Fix TypeError: Cannot read property 'name'

### DIFF
--- a/app/client/startup/startup.js
+++ b/app/client/startup/startup.js
@@ -32,7 +32,7 @@ Meteor.startup(function() {
       }
       app.moderatorPreference = pref;
 
-      if (!app.author.name && app.appId ===
+      if (app && app.author && !app.author.name && app.appId ===
           "7qvcjh7gk0rzdx1s3c8gufd288sesf6vvdt297756xcv4q8xxvhh") {
         // Jack forgot to set his name in Keybase.
         app.author.name = "Jack Singleton";


### PR DESCRIPTION
Fix a bug that prevents the experimental app market from loading correctly.

I believe @kentonv introduced this bug while writing an imperative workaround for a @jacksingleton app packaging problem. Life is strange.