### PR TITLE
Make author name be optional

### DIFF
--- a/app/client/collections/apps.js
+++ b/app/client/collections/apps.js
@@ -142,7 +142,8 @@ var appsBaseSchema = {
     type: Number,
   },
   'author.name': {
-    type: String
+    type: String,
+    optional: true
   },
   'author.githubUsername': {
     type: String,


### PR DESCRIPTION
This resolves a bug where we were not displaying information about the Angr app.