### PR TITLE
Switch to Sandstorm-hosted Source Sans

### DIFF
--- a/app/client/stylesheets/main.scss
+++ b/app/client/stylesheets/main.scss
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600);
+@import url(https://sandstorm.io/fonts/sourcesans.css);
 @import "variables";
 
 @font-face {

--- a/app/server/lib/browser-policy.js
+++ b/app/server/lib/browser-policy.js
@@ -1,6 +1,6 @@
 BrowserPolicy.content.allowImageOrigin("*");
-BrowserPolicy.content.allowStyleOrigin('https://fonts.googleapis.com');
-BrowserPolicy.content.allowFontOrigin('https://fonts.gstatic.com');
+BrowserPolicy.content.allowStyleOrigin('https://sandstorm.io');
+BrowserPolicy.content.allowFontOrigin('https://sandstorm.io');
 BrowserPolicy.content.allowInlineStyles();
 BrowserPolicy.content.allowFontDataUrl();
 BrowserPolicy.content.allowScriptOrigin('https://sandstorm.io');


### PR DESCRIPTION
I'm not set up to test Meteor on this device, but this should work. (I probably should try to build the app market at some point.)