### PR TITLE
Support GitLab and Bitbucket with Bug Report link

### DIFF
--- a/app/client/templates/single-app/single-app.js
+++ b/app/client/templates/single-app/single-app.js
@@ -159,7 +159,7 @@ Template.SingleApp.helpers({
 
   bugReportLink: function() {
     var app = Apps.findOne({_id: Template.instance().appId});
-    if (app.codeLink && app.codeLink.startsWith("https://github.com/")) {
+    if (app.codeLink && (app.codeLink.startsWith("https://github.com/") || app.codeLink.startsWith("https://gitlab.com/") || app.codeLink.startsWith("https://bitbucket.org/"))) {
       return app.codeLink + "/issues";
     }
   },


### PR DESCRIPTION
I haven't tested this, but it's incredibly simple code.

Mercurial would be an example of a current Sandstorm app that would benefit from this, as it is hosted on Bitbucket.